### PR TITLE
Remove $crate from core macro calls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 /// hex representation
 #[macro_export]
 macro_rules! assert_eq_hex {
-    ($left:expr, $right:expr) => ({
+    ($left:expr, $right:expr $(,)?) => ({
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
@@ -28,9 +28,6 @@ macro_rules! assert_eq_hex {
                 }
             }
         }
-    });
-    ($left:expr, $right:expr,) => ({
-        $crate::assert_eq!($left, $right)
     });
     ($left:expr, $right:expr, $($arg:tt)+) => ({
         match (&($left), &($right)) {
@@ -55,7 +52,7 @@ macro_rules! assert_eq_hex {
 /// hex representation
 #[macro_export]
 macro_rules! assert_ne_hex {
-    ($left:expr, $right:expr) => ({
+    ($left:expr, $right:expr $(,)?) => ({
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
@@ -69,9 +66,6 @@ macro_rules! assert_ne_hex {
             }
         }
     });
-    ($left:expr, $right:expr,) => {
-        $crate::assert_ne!($left, $right)
-    };
     ($left:expr, $right:expr, $($arg:tt)+) => ({
         match (&($left), &($right)) {
             (left_val, right_val) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ macro_rules! assert_eq_hex {
                     panic!(r#"assertion failed: `(left == right)`
   left: `0x{:02x?}`,
  right: `0x{:02x?}`: {}"#, &*left_val, &*right_val,
-                           $crate::format_args!($($arg)+))
+                           format_args!($($arg)+))
                 }
             }
         }
@@ -76,7 +76,7 @@ macro_rules! assert_ne_hex {
                     panic!(r#"assertion failed: `(left != right)`
   left: `0x{:02x?}`,
  right: `0x{:02x?}`: {}"#, &*left_val, &*right_val,
-                           $crate::format_args!($($arg)+))
+                           format_args!($($arg)+))
                 }
             }
         }


### PR DESCRIPTION
`$crate` was likely imported by accident from `core`. Both a trailing semicolon and format string (+ optional arguments) would fail to compile with this in place.